### PR TITLE
Add support for Solaris and illumos

### DIFF
--- a/src/pytestsysstats/plugin.py
+++ b/src/pytestsysstats/plugin.py
@@ -93,6 +93,9 @@ class SystemStatsReporter:
             if platform.is_freebsd():
                 # FreeBSD doesn't apparently support uss
                 self.sys_stats_mem_type = "rss"
+            if platform.is_sunos():
+                # Solaris and illumos doesn't apparently support uss
+                self.sys_stats_mem_type = "rss"
         else:
             self.sys_stats_mem_type = "rss"
 

--- a/tests/functional/test_syststats.py
+++ b/tests/functional/test_syststats.py
@@ -96,6 +96,7 @@ def test_basic_sys_stats(pytester):
 
 
 @pytest.mark.skip_on_freebsd
+@pytest.mark.skip_on_sunos
 def test_basic_sys_stats_uss(pytester):
     pytester.makepyfile(
         """


### PR DESCRIPTION
Test results with this change:
```
============================= test session starts ==============================
platform sunos5 -- Python 3.9.19, pytest-8.3.1, pluggy-1.5.0 -- /usr/bin/python3.9
cachedir: .pytest_cache
rootdir: /data/builds/oi-userland/components/python/pytest-system-statistics/build/amd64-3.9
configfile: pytest.ini
testpaths: tests/
plugins: skip-markers-1.5.1, system-statistics-1.0.2
collecting ... collected 7 items

tests/functional/test_syststats.py::test_sys_stats_not_verbose PASSED    [ 14%]
tests/functional/test_syststats.py::test_sys_stats_not_verbose_enough PASSED [ 28%]
tests/functional/test_syststats.py::test_sys_stats_disabled PASSED       [ 42%]
tests/functional/test_syststats.py::test_basic_sys_stats PASSED          [ 57%]
tests/functional/test_syststats.py::test_basic_sys_stats_uss SKIPPED     [ 71%]
tests/functional/test_syststats.py::test_proc_sys_stats PASSED           [ 85%]
tests/functional/test_syststats.py::test_proc_sys_stats_no_children PASSED [100%]

========================= 6 passed, 1 skipped in 1.76s =========================

```

Fixes #7.